### PR TITLE
Update AI model and configuration in SemanticKernelService

### DIFF
--- a/AIKernelClient/Services/SemanticKernelService.cs
+++ b/AIKernelClient/Services/SemanticKernelService.cs
@@ -11,7 +11,7 @@ namespace AIKernelClient.Services;
 public class SemanticKernelService:ISemanticKernelService
 {
     // Set upcredentials and endpoints.
-    private const string chatModel = "gpt-4o-mini"; // or gpt-4 (but it is expensive)
+    private const string chatModel = "gpt-5-nano"; // or gpt-4 (but it is expensive) gpt-5-mini gpt-5-nano gpt-4o-mini
     private const string openApiOrgId = "org-RRBnXYYjTq5b4qr7TLaaHsLD";
 
     //private const string apiLocation = "rh8xzzh8-5042.usw3.devtunnels.ms";
@@ -117,12 +117,12 @@ public class SemanticKernelService:ISemanticKernelService
             
             _chatCompletionService = _kernel.GetRequiredService<IChatCompletionService>();
 
-            // tell the openAI connector to invoke sevice if the prompt is unnderstood
+            // tell the openAI connector to invoke service if the prompt is understood
             _openAIPromptExecutionSettings = new()
             {
-                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: true),
-                Temperature = 0.4,      // Precise and deterministic -- Creativity level (0 = deterministic, 2 = highly random)
-                TopP = 0.4,             // Limits randomness
+                ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions,
+                //FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(autoInvoke: true),
+                Temperature = 1,      // Precise and deterministic -- Creativity level (0 = deterministic, 2 = highly random)
                 FrequencyPenalty = 0.0, // Allows repeated words like "Turning on..."
                 PresencePenalty = 0.0,  // Prevents forced response variations
             };

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The Solution is made of **4 C# .net 9.0 projects**
 
 2. **AIKernelClient:** The controller application  **talking to the AI**: a cross platform **MAUI** (Multi platform) application that controls the service through prompts Using Semantic Kernel with a connector to OpenAI (Chat GPT 4o Mini) it relays service calls from the AI.
       - Plugin creation and propmting occurs in the class Services/**SemanticKernelService.cs** injected to the MainPageViewModel.cs
-      - **SemanticKernelService.cs** contains some hardcoded credentials to OpenAI (not an elegant solution but easy to replace with yours to test with)
+      - **SemanticKernelService.cs** will create the kernel, load the plugin, and will call the AI model with the prompt
+      - **ApiKeyProvider.cs** will provide the OpenAI API key from secure storage or environment variable
       - **MainPageViewModel** will initialize the SemanticKernelService (**InitializeKernelAndPluginAsync**) and will call it to prompt the AI (**GetResponseAsync**)
       - Speech to Text is also implemented in the **MainPageViewModel.cs** class, by dependency injection.
 3. **WPFPassiveClient:** A visualization application  that displays the changes done by the controler on the service by polling at regular intervals the changes made to the service resources (lights) (WPF application). 


### PR DESCRIPTION
- Changed `chatModel` from "gpt-4o-mini" to "gpt-5-nano" for improved performance.
- Corrected a comment typo from "unnderstood" to "understood."
- Modified `_openAIPromptExecutionSettings`:
  - Replaced `FunctionChoiceBehavior` with `ToolCallBehavior` set to `AutoInvokeKernelFunctions`.
  - Increased `Temperature` from `0.4` to `1` for more creative responses.
- Updated README.md to clarify the role of `SemanticKernelService.cs` in the architecture.
- Provided additional context on the solution structure and integration with LightControllerAPI.